### PR TITLE
Package rename for npmjs.com

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@slashtags/auth",
+    "name": "@synonymdev/slashtags-auth",
     "version": "0.0.1",
     "description": "Bidirectional authentication for keypair verification through attestation.",
     "type": "module",


### PR DESCRIPTION
Package published to https://www.npmjs.com/package/@synonymdev/slashtags-auth