### PR TITLE
Fix: Ensure variable global is available in browser window

### DIFF
--- a/packages/sdk/src/storage.browser.js
+++ b/packages/sdk/src/storage.browser.js
@@ -1,6 +1,11 @@
 import RAW from 'random-access-web'
 import RAM from 'random-access-memory'
 
+if(typeof window !== "undefined"){
+  // @ts-ignore
+  global = window
+}
+
 const requestFileSystem =
   // @ts-ignore
   global.requestFileSystem || global.webkitRequestFileSystem


### PR DESCRIPTION
storage.browser.js assumes "global" var is available in web browser causing package to crash
fix sets global var if window object is present