### PR TITLE
Fix failing tests, run skipped test

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "build": "echo no need to build",
     "clean": "rimraf types",
     "lint": "standard --fix",
-    "test": "brittle test/** -cov",
+    "test": "brittle test/*.js -cov",
     "depcheck": "npx depcheck --ignores='@types/*'",
     "fullcheck": "npm run lint && npm run clean && npm run build && npm run test && npm run depcheck",
     "prepublishOnly": "npm run fullcheck"

--- a/packages/cli/test/relay.js
+++ b/packages/cli/test/relay.js
@@ -7,7 +7,7 @@ import Stream from '@hyperswarm/dht-relay/ws'
 
 import run from '../lib/daemon/index.js'
 
-test.skip('basic', async t => {
+test('basic', async t => {
   const testnet = await createTestnet(4, t.teardown)
 
   const relay = await run({ dhtOpts: testnet })
@@ -20,7 +20,6 @@ test.skip('basic', async t => {
 
   const server = alice.createServer(socket => {
     st.alike(socket.remotePublicKey, bob.defaultKeyPair.publicKey)
-    socket.destroy()
   })
   await server.listen()
 
@@ -29,11 +28,12 @@ test.skip('basic', async t => {
   t.ok(await socket.opened)
   await st
 
-  relay.close()
-  alice.destroy()
-  bob.destroy()
-  socket.destroy()
-  server.close()
+  await socket.destroy()
+  await relay.close()
+  await alice.destroy()
+  await bob.destroy()
+
+  await server.close()
 })
 
 /** @param {number} port */

--- a/packages/drive/test/keys.js
+++ b/packages/drive/test/keys.js
@@ -17,6 +17,7 @@ test('dont store secretKey at rest', async (t) => {
 
   t.ok(drivestore.corestore.primaryKey)
 
+  await corestore.close()
   const stored = fs.readFileSync(path.join(dir, 'primary-key'))
   t.unlike(stored, drivestore.corestore.primaryKey)
 })

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "clean": "rimraf types",
     "lint": "standard --fix",
-    "test": "brittle test/** -cov",
+    "test": "brittle test/*.js -cov",
     "depcheck": "npx depcheck",
     "fullcheck": "npm run lint && npm run clean && npm run build && npm run test && npm run depcheck",
     "prepublishOnly": "npm run fullcheck"

--- a/packages/sdk/test/lifecycle.js
+++ b/packages/sdk/test/lifecycle.js
@@ -27,6 +27,7 @@ test('not store primary key in rest', async t => {
 
   await sdk.ready()
 
+  await sdk.corestore.close()
   const stored = fs.readFileSync(path.join(dir, 'primary-key'))
 
   t.unlike(stored, sdk.primaryKey)

--- a/packages/slashtag/package.json
+++ b/packages/slashtag/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "clean": "rimraf types",
     "lint": "standard --fix",
-    "test": "brittle test/** -cov",
+    "test": "brittle test/*.js -cov",
     "depcheck": "npx depcheck",
     "fullcheck": "npm run lint && npm run clean && npm run build && npm run test && npm run depcheck",
     "prepublishOnly": "npm run fullcheck"

--- a/packages/slashtag/test/listen.js
+++ b/packages/slashtag/test/listen.js
@@ -4,7 +4,7 @@ import createTestnet from '@hyperswarm/testnet'
 
 import { Slashtag } from '../index.js'
 
-test('server - listen', async t => {
+test('server - listen',async t => {
   const testnet = await createTestnet(3, t.teardown)
 
   const alice = new Slashtag(testnet)
@@ -27,8 +27,8 @@ test('server - listen', async t => {
   t.ok(serverSocket, 'save socket in slashtag.sockets')
 
   await alice.close()
-  await dht.destroy()
   await socket.destroy()
+  await dht.destroy()
 })
 
 test('server - unlisten', async t => {
@@ -54,6 +54,6 @@ test('server - unlisten', async t => {
   t.is(alice.dht.listening.size, 0, 'unlistened on the dht')
 
   await alice.close()
-  await dht.destroy()
   await socket.destroy()
+  await dht.destroy()
 })

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "clean": "rimraf types",
     "lint": "standard --fix",
-    "test": "brittle test/** -cov",
+    "test": "brittle test/*.js -cov",
     "depcheck": "npx depcheck",
     "fullcheck": "npm run lint && npm run clean && npm run build && npm run test && npm run depcheck",
     "prepublishOnly": "npm run fullcheck"


### PR DESCRIPTION
- Fix brittle test path, unskip test
- Fix ordering of close methods to avoid client terminated early error and hanging test
- Close corestore before reading primary-key file via fs