### PR TITLE
sdk: allow slashtag to accept custom corestores

### DIFF
--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -90,9 +90,12 @@ export class SDK extends EventEmitter {
   /**
    * Creates a Slashtag by name.
    * @param {string} [name] utf8 encoded string
+   * @param {object} [opts] slashtag instantiation options
+   * @param {Corestore} [opts.corestore] corestore
+   *
    * @throws {Error} throws an error if the SDK or its corestore is closing
    */
-  slashtag (name) {
+  slashtag (name, opts = {}) {
     if (this.closed) throw new Error('SDK is closed')
     const key = this.createKeyPair(name).publicKey
     const existing = this.slashtags.get(key)
@@ -100,8 +103,8 @@ export class SDK extends EventEmitter {
 
     const slashtag = new Slashtag({
       keyPair: this.createKeyPair(name),
-      corestore: this.corestore,
-      dht: this.dht
+      dht: this.dht,
+      corestore: opts?.corestore || this.corestore
     })
 
     this.slashtags.set(key, slashtag)

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -92,6 +92,8 @@ export class SDK extends EventEmitter {
    * @param {string} [name] utf8 encoded string
    * @param {object} [opts] slashtag instantiation options
    * @param {Corestore} [opts.corestore] corestore
+   * @param {DHT} [opts.dht] dht
+   * @param {import('hypercore').KeyPair} [opts.keyPair] keyPair
    *
    * @throws {Error} throws an error if the SDK or its corestore is closing
    */
@@ -102,8 +104,8 @@ export class SDK extends EventEmitter {
     if (existing) return existing
 
     const slashtag = new Slashtag({
-      keyPair: this.createKeyPair(name),
-      dht: this.dht,
+      keyPair: opts?.keyPair || this.createKeyPair(name),
+      dht: opts?.dht || this.dht,
       corestore: opts?.corestore || this.corestore
     })
 

--- a/packages/sdk/test/slashtag.js
+++ b/packages/sdk/test/slashtag.js
@@ -3,6 +3,7 @@ import createTestnet from '@hyperswarm/testnet'
 import RAM from 'random-access-memory'
 
 import SDK from '../index.js'
+import Corestore from 'corestore'
 
 test('slashtag - deduplicate', async (t) => {
   const sdk = new SDK({ storage: RAM })
@@ -55,6 +56,25 @@ test('slashtag - announce public drive', async (t) => {
   t.ok(discovery.isClient)
   t.ok(discovery.isServer)
   t.alike(discovery.topic, drive.discoveryKey)
+
+  await sdk.close()
+})
+
+test('slashtag - separate corestores', async (t) => {
+  const testnet = await createTestnet(3, t.teardown)
+  const sdk = new SDK({ ...testnet, storage: RAM })
+
+  const alice = sdk.slashtag('alice', { corestore: new Corestore(RAM) })
+  const aliceDrive = alice.drivestore.get()
+  await aliceDrive.ready()
+
+  const bob = sdk.slashtag('bob', { corestore: new Corestore(RAM) })
+  const bobDrive = bob.drivestore.get()
+  await bobDrive.ready()
+
+  t.ok(aliceDrive.corestore.cores.values())
+  t.ok(bobDrive.corestore.cores.values())
+  t.not(aliceDrive.corestore.cores.values(), bobDrive.corestore.cores.values())
 
   await sdk.close()
 })


### PR DESCRIPTION
Whiledoing something like:
```js
    const slashtag = this.sdk.slashtag(feedId)
    const drive = slashtag.drivestore.get(feedId)
```

I discovered that drives for different `feedIds`  share the same `corestore`. 

This cause issues with deletion of drives as:
```js
   cores = [drive.core, drive.blobs.core] // destroys too little
```
while
```
   cores = Array.from(drive.corestore.cores.values()) // destroys everything
```

