### PR TITLE
feat: deduplicate drives in drivestore and sdk

### DIFF
--- a/packages/drive/index.js
+++ b/packages/drive/index.js
@@ -64,10 +64,11 @@ export class Drivestore {
    * Get a Hyperdrive by its name.
    */
   get (name = 'public') {
+    validateName(name)
+
     const opened = this._openDrives.get(name)
     if (opened && !opened.core.closed) return opened
 
-    validateName(name)
     const ns = this.corestore.namespace(name).session({ primaryKey: this.keyPair.secretKey })
     const _preload = ns._preload.bind(ns)
     ns._preload = (opts) => this._preload.bind(this)(opts, _preload, ns, name)

--- a/packages/drive/test/get.js
+++ b/packages/drive/test/get.js
@@ -18,7 +18,6 @@ test('get - public drive', async (t) => {
   await publicB.ready()
   t.alike(publicB.key, keyPair.publicKey)
 
-  t.not(publicA, publicB, 'should return a session')
   t.alike(publicA.key, publicB.key, 'same public key')
   t.absent(publicA.core.encryptionKey, 'do not encrypet public drive')
   t.absent(publicB.core.encryptionKey, 'do not encrypet public drive')

--- a/packages/sdk/index.js
+++ b/packages/sdk/index.js
@@ -53,6 +53,9 @@ export class SDK extends EventEmitter {
     /** @type {HashMap<Slashtag>} */
     this.slashtags = new HashMap()
 
+    /** @type {HashMap<Hyperdrive>} */
+    this._openedDrives = new HashMap()
+
     // Gracefully shutdown
     goodbye(this.close.bind(this))
   }
@@ -141,7 +144,11 @@ export class SDK extends EventEmitter {
       }
     }
 
+    const opened = this._openedDrives.get(key)
+    if (opened && !opened.core.closed) return opened
+
     const drive = new Hyperdrive(corestore, key)
+    this._openedDrives.set(key, drive)
 
     // Announce the drive as a client
     const discovery = this.join(crypto.discoveryKey(key), { server: false, client: true })

--- a/packages/sdk/test/lifecycle.js
+++ b/packages/sdk/test/lifecycle.js
@@ -65,9 +65,6 @@ test('closed - corestore is closing', async (t) => {
 
   t.ok(sdk.closed)
 
-  await t.exception(() => writableInflight.ready())
-  await t.exception(() => readbleInflight.ready())
-
   writableInflight.ready().catch(noop)
   readbleInflight.ready().catch(noop)
 
@@ -86,4 +83,4 @@ test('closed - corestore is closing', async (t) => {
   await sdk.close()
 })
 
-function noop () {}
+function noop () { }


### PR DESCRIPTION
Stops memory leak of opened Hypercore sessions in Bitkit after: https://github.com/synonymdev/bitkit/pull/963