### PR TITLE
feat(rpc): support instantiating using Hyperswarm instead of Slashtag

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -44,7 +44,7 @@ declare module 'hyperswarm' {
     topics: Uint8Array[]
   }
 
-  export = class hyperswarm extends EventEmitter {
+  class Hyperswarm extends EventEmitter {
     constructor(opts?: any);
     server: Server;
     connections: Iterable;
@@ -71,6 +71,8 @@ declare module 'hyperswarm' {
 
     on(event: 'connection', listener: (connection: any, peerInfo: PeerInfo) => any)
   };
+
+  export = Hyperswarm
 }
 
 // file://./node_modules/b4a/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -6358,13 +6358,13 @@
       }
     },
     "node_modules/hyperswarm": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.3.7.tgz",
-      "integrity": "sha512-COL8cMmBUa0ElZ85oFT1KQnZh1UkfJ75VavyypXZplGErlajqbnI2CDNF9K7cGiIk7xXR0RI6otx3495WSOB2Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.5.0.tgz",
+      "integrity": "sha512-wS+aURKcFzeeXDQBgQGVcO7rEjIY9p5iLaHcwlThQFFEnpr0b/UoMyNDg5hyuNrrxnt89Sz6tb0PS++lWeoDyQ==",
       "dependencies": {
-        "@hyperswarm/dht": "^6.0.1",
         "b4a": "^1.3.1",
         "events": "^3.3.0",
+        "hyperdht": "^6.5.2",
         "safety-catch": "^1.0.2",
         "shuffled-priority-queue": "^2.1.0"
       }
@@ -12658,7 +12658,7 @@
     },
     "packages/drive": {
       "name": "@synonymdev/slashdrive",
-      "version": "1.0.0-wip.2",
+      "version": "1.0.0-alpha.21",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.0",
@@ -12678,11 +12678,14 @@
     },
     "packages/rpc": {
       "name": "@synonymdev/slashtags-rpc",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "b4a": "^1.6.0",
-        "protomux-rpc": "^1.3.0"
+        "hyperswarm": "^4.5.0",
+        "protomux-rpc": "^1.3.0",
+        "turbo-hash-map": "^1.0.3"
       },
       "devDependencies": {
         "@hyperswarm/testnet": "^3.1.0",
@@ -12690,7 +12693,6 @@
         "brittle": "^3.0.2",
         "compact-encoding": "^2.11.0",
         "depcheck": "^1.4.3",
-        "hyperdht": "^6.5.2",
         "standard": "^17.0.0",
         "typescript": "^4.8.2",
         "z32": "^1.0.0"
@@ -12698,12 +12700,12 @@
     },
     "packages/sdk": {
       "name": "@synonymdev/slashtags-sdk",
-      "version": "1.0.0-wip.4",
+      "version": "1.0.0-alpha.39",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/dht-relay": "^0.3.0",
-        "@synonymdev/slashtag": "^1.0.0-wip.1",
-        "@synonymdev/slashtags-url": "^1.0.0-wip.1",
+        "@synonymdev/slashtag": "^1.0.0-alpha.25",
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "b4a": "^1.6.0",
         "corestore": "^6.2.1",
         "graceful-goodbye": "^1.1.0",
@@ -12752,11 +12754,11 @@
     },
     "packages/slashtag": {
       "name": "@synonymdev/slashtag",
-      "version": "1.0.0-wip.1",
+      "version": "1.0.0-alpha.25",
       "license": "MIT",
       "dependencies": {
-        "@synonymdev/slashdrive": "^1.0.0-alpha.20",
-        "@synonymdev/slashtags-url": "^1.0.0-alpha.1",
+        "@synonymdev/slashdrive": "^1.0.0-alpha.21",
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "corestore": "^6.2.1",
         "hyperdht": "^6.5.2",
         "random-access-memory": "^5.0.1",
@@ -12773,7 +12775,7 @@
     },
     "packages/url": {
       "name": "@synonymdev/slashtags-url",
-      "version": "1.0.0-wip.1",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.0",
@@ -14640,8 +14642,8 @@
       "requires": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "@hyperswarm/testnet": "^3.1.0",
-        "@synonymdev/slashdrive": "^1.0.0-alpha.20",
-        "@synonymdev/slashtags-url": "^1.0.0-alpha.1",
+        "@synonymdev/slashdrive": "^1.0.0-alpha.21",
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "brittle": "^3.1.0",
         "corestore": "^6.2.1",
         "depcheck": "^1.4.3",
@@ -14688,13 +14690,15 @@
       "requires": {
         "@hyperswarm/testnet": "^3.1.0",
         "@synonymdev/slashtag": "^1.0.0-alpha.10",
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "b4a": "^1.6.0",
         "brittle": "^3.0.2",
         "compact-encoding": "^2.11.0",
         "depcheck": "^1.4.3",
-        "hyperdht": "^6.5.2",
+        "hyperswarm": "^4.5.0",
         "protomux-rpc": "^1.3.0",
         "standard": "^17.0.0",
+        "turbo-hash-map": "^1.0.3",
         "typescript": "^4.8.2",
         "z32": "^1.0.0"
       }
@@ -14704,8 +14708,8 @@
       "requires": {
         "@hyperswarm/dht-relay": "^0.3.0",
         "@hyperswarm/testnet": "^3.1.0",
-        "@synonymdev/slashtag": "^1.0.0-wip.1",
-        "@synonymdev/slashtags-url": "^1.0.0-wip.1",
+        "@synonymdev/slashtag": "^1.0.0-alpha.25",
+        "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
         "b4a": "^1.6.0",
         "brittle": "^3.0.2",
         "corestore": "^6.2.1",
@@ -17932,13 +17936,13 @@
       }
     },
     "hyperswarm": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.3.7.tgz",
-      "integrity": "sha512-COL8cMmBUa0ElZ85oFT1KQnZh1UkfJ75VavyypXZplGErlajqbnI2CDNF9K7cGiIk7xXR0RI6otx3495WSOB2Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.5.0.tgz",
+      "integrity": "sha512-wS+aURKcFzeeXDQBgQGVcO7rEjIY9p5iLaHcwlThQFFEnpr0b/UoMyNDg5hyuNrrxnt89Sz6tb0PS++lWeoDyQ==",
       "requires": {
-        "@hyperswarm/dht": "^6.0.1",
         "b4a": "^1.3.1",
         "events": "^3.3.0",
+        "hyperdht": "^6.5.2",
         "safety-catch": "^1.0.2",
         "shuffled-priority-queue": "^2.1.0"
       }

--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -69,39 +69,11 @@ const bobFoo = new Foo(bob);
 const response = await bobFoo.echo(alice.key, 'hello world');
 ```
 
-#### Use without Slashtag
-
-If the RPC doesn't reuqire Slashtag for anything other than establish a connection, you can pass your own stream:
-
-```js
-import DHT from '@hyperswarm/dht'
-import SlashtagsRPC from '@synonymdev/slashtags-rpc';
-import c from 'compact-encoding';
-
-const alice = new DHT();
-const server = alice.createServer()
-await server.listen();
-
-class Foo extends SlashtagsRPC {
-  //...
-}
-
-const aliceFoo = new Foo();
-server.on('connection', (stream) => aliceFoo.setup(stream))
-aliceFoo.on('echo', (req) => {
-  console.log(req) // req = 'hello world'
-})
-
-const bob = new DHT();
-const bobFoo = new Foo();
-const stream = bob.connect(server.address().publicKey)
-await stream.opened
-
-const rpc = bobFoo.setup(stream)
-const response = await rpc.request('echo', 'hello world')
-```
-
 ## API
+
+#### const rpc = new SlashtagsRPC({swarm})
+
+Create a new instance of SlashtagsRPC using a [Hyperswarm](https://github.com/holepunchto/hyperswarm) instance.
 
 #### `id`
 
@@ -147,8 +119,4 @@ An array of methods objects that should be as following:
 
 Returns a [ProtomuxRPC](https://www.npmjs.com/package/protomux-rpc) instance after connecting to a Slashtag by its key, id or url. If connection is already opened, the same RPC instance is returned.
 
-Internally, it uses `Slashtags.connect(key)` then sets up the RPC instance using `setup(stream)`
-
-#### `setup(stream)`
-
-Create a new [ProtomuxRPC](https://www.npmjs.com/package/protomux-rpc) instance on any stream if doesn't already exist, otherwise it will return the existing RPC.
+this is an idempotent operation, meaning if there is already an existing opened connection, it won't create new ones.

--- a/packages/rpc/index.js
+++ b/packages/rpc/index.js
@@ -1,15 +1,35 @@
 const ProtomuxRPC = require('protomux-rpc')
 const EventEmitter = require('events')
 const b4a = require('b4a')
+const HashMap = require('turbo-hash-map')
+const SlashURL = require('@synonymdev/slashtags-url')
 
 const RPCS_SYMBOL = Symbol.for('slashtags-rpcs')
+const CONNECT_TO_SEEDER_TIMEOUT = 10000
 
 class SlashtagsRPC extends EventEmitter {
-  /** @param {Slashtag} [slashtag] */
-  constructor (slashtag) {
+  /**
+   * @param {object} opts
+   * @param {import('hyperswarm')} opts.swarm
+   **/
+  constructor (opts) {
     super()
-    this.slashtag = slashtag
-    this.slashtag?.on('connection', this.setup.bind(this))
+
+    /**
+     * @type {import('@synonymdev/slashtag')}
+     * @deprecated use new SlashtagsRPC({swarm}) instead
+     */
+    // @ts-ignore
+    this.slashtag = opts
+
+    this._allConnections = new HashMap()
+    this._swarm = opts.swarm
+
+    if (this._swarm) {
+      this._swarm.on('connection', this.setup.bind(this))
+    } else {
+      this.slashtag.on('connection', this.setup.bind(this))
+    }
   }
 
   /**
@@ -81,15 +101,74 @@ class SlashtagsRPC extends EventEmitter {
   }
 
   /**
+   * @param {Uint8Array | string} key
+   */
+  async _rpcFromSwarm (key) {
+    /** @type {Uint8Array} */
+    const publicKey =
+      typeof key === 'string'
+        ? key.startsWith('slash')
+          ? SlashURL.parse(key).key
+          : SlashURL.decode(key)
+        : key
+
+    // duplicate logic from Hyperswarm's internal connections management, but swarm._allConnections is not a public API, so we can't rely on it.
+    const existingConnection = this._allConnections.get(publicKey)
+    if (existingConnection) {
+      // this.setup() is idempotent
+      return this.setup(existingConnection)
+    }
+
+    this._swarm.joinPeer(publicKey)
+
+    // Await for connecting to every seeder for unit testing convenience
+    return new Promise((resolve) => {
+      /** @param {import('protomux-rpc')} rpc */
+      const cleanupAndResolve = (rpc) => {
+        this._swarm.removeListener('connection', onConnection)
+        resolve(rpc)
+      }
+
+      /** @param {SecretStream} connection */
+      const onConnection = (connection) => {
+        if (b4a.equals(connection.remotePublicKey, publicKey)) {
+          this._allConnections.set(publicKey, connection)
+          connection.once('close', () => {
+            this._allConnections.delete(publicKey)
+          })
+
+          const rpc = this.setup(connection)
+          cleanupAndResolve(rpc)
+        }
+      }
+
+      // Timeout to avoid blocking this.ready()
+      setTimeout(cleanupAndResolve, CONNECT_TO_SEEDER_TIMEOUT)
+
+      this._swarm.on('connection', onConnection.bind(this))
+    })
+  }
+
+  /**
+   * For backward compatibility.
+   *
+   * @param {Uint8Array | string} key
+   *
+   * @deprecated use new SlashtagsRPC({swarm}) instead
+   */
+  async _rpcFromSlashtag (key) {
+    const socket = this.slashtag.connect(key)
+    await socket.opened
+    return this.setup(socket)
+  }
+
+  /**
    * Connect to a peer if not already connected, and return Protomux RPC instance.
    * @param {Parameters<Slashtag['connect']>[0]} key
    * @returns {Promise<ProtomuxRPC | undefined>}
    */
   async rpc (key) {
-    if (!this.slashtag) throw new Error('Can not call rpc() if not initialized with a Slashtag instance')
-    const socket = this.slashtag.connect(key)
-    await socket.opened
-    return this.setup(socket)
+    return this._swarm ? this._rpcFromSwarm(key) : this._rpcFromSlashtag(key)
   }
 }
 

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synonymdev/slashtags-rpc",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "helper module for creating RPCs using Slashtags nodes",
   "main": "index.js",
   "types": "types/index.d.ts",
@@ -29,8 +29,11 @@
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {
+    "@synonymdev/slashtags-url": "^1.0.0-alpha.3",
     "b4a": "^1.6.0",
-    "protomux-rpc": "^1.3.0"
+    "hyperswarm": "^4.5.0",
+    "protomux-rpc": "^1.3.0",
+    "turbo-hash-map": "^1.0.3"
   },
   "devDependencies": {
     "@hyperswarm/testnet": "^3.1.0",
@@ -38,7 +41,6 @@
     "brittle": "^3.0.2",
     "compact-encoding": "^2.11.0",
     "depcheck": "^1.4.3",
-    "hyperdht": "^6.5.2",
     "standard": "^17.0.0",
     "typescript": "^4.8.2",
     "z32": "^1.0.0"

--- a/packages/rpc/test/swarm.js
+++ b/packages/rpc/test/swarm.js
@@ -2,7 +2,8 @@ const test = require('brittle')
 const Slashtag = require('@synonymdev/slashtag')
 const createTestnet = require('@hyperswarm/testnet')
 const c = require('compact-encoding')
-const z32 = require('z32')
+const b4a = require('b4a')
+const Hyperswarm = require('hyperswarm')
 
 const SlashtagsRPC = require('../index.js')
 
@@ -21,7 +22,7 @@ class Foo extends SlashtagsRPC {
 
   /** @param {import('@hyperswarm/secret-stream')} socket */
   handshake (socket) {
-    return this.id + '-handshake:for:' + z32.encode(socket.remotePublicKey)
+    return this.id + '-handshake:for:' + b4a.toString(socket.remotePublicKey, 'hex')
   }
 
   /**
@@ -29,7 +30,7 @@ class Foo extends SlashtagsRPC {
    * @param {import('@hyperswarm/secret-stream')} socket
    */
   onopen (handshake, socket) {
-    this.emit('handshake', handshake, z32.encode(socket.remotePublicKey))
+    this.emit('handshake', handshake, socket.remotePublicKey)
   }
 
   get methods () {
@@ -66,31 +67,18 @@ class Bar extends Foo {
   }
 }
 
-test('missing id', async t => {
-  const testnet = await createTestnet(1, t.teardown)
-  const alice = new Slashtag(testnet)
-
-  class MissingID extends SlashtagsRPC { }
-
-  const instance = new MissingID(alice)
-  // @ts-ignore
-  await t.exception(() => instance.setup({}), /id should be defined/)
-
-  alice.close()
-})
-
-test('basic', async t => {
+test('hyperswarm - basic', async t => {
   const testnet = await createTestnet(3, t.teardown)
 
-  const alice = new Slashtag(testnet)
-  const bob = new Slashtag(testnet)
+  const alice = new Hyperswarm(testnet)
+  const bob = new Hyperswarm(testnet)
 
-  const aliceFoo = new Foo(alice)
+  const aliceFoo = new Foo({ swarm: alice })
     ; (() => {
     // Multiple instances shouldn't create any issues
-    return new Foo(alice)
+    return new Foo({ swarm: alice })
   })()
-  const bobFoo = new Foo(bob)
+  const bobFoo = new Foo({ swarm: bob })
 
   await alice.listen()
 
@@ -98,28 +86,28 @@ test('basic', async t => {
   ht.plan(4)
 
   aliceFoo.on('handshake', (handshake, remoteID) => {
-    ht.is(handshake, 'foo-handshake:for:' + alice.id, 'correct handshake')
-    ht.is(remoteID, bob.id, 'emit handshake event correctly')
+    ht.is(handshake, 'foo-handshake:for:' + b4a.toString(alice.keyPair.publicKey, 'hex'), 'correct handshake')
+    ht.alike(remoteID, bob.keyPair.publicKey, 'emit handshake event correctly')
   })
 
   bobFoo.on('handshake', (handshake, remoteID) => {
-    ht.is(handshake, 'foo-handshake:for:' + bob.id, 'correct handshake')
-    ht.is(remoteID, alice.id, 'emit handshake event correctly')
+    ht.is(handshake, 'foo-handshake:for:' + b4a.toString(bob.keyPair.publicKey, 'hex'), 'correct handshake')
+    ht.alike(remoteID, alice.keyPair.publicKey, 'emit handshake event correctly')
   })
 
   aliceFoo.once('echo', req => t.is(req, 'foobar'))
-  t.is(await bobFoo.echo(alice.key, 'foobar'), 'foobar')
+  t.is(await bobFoo.echo(alice.keyPair.publicKey, 'foobar'), 'foobar')
 
   aliceFoo.once('echo', req => t.is(req, 'foobar 2'))
-  t.is(await bobFoo.echo(alice.key, 'foobar 2'), 'foobar 2')
+  t.is(await bobFoo.echo(alice.keyPair.publicKey, 'foobar 2'), 'foobar 2')
 
   await ht
 
-  await alice.close()
-  await bob.close()
+  await alice.destroy()
+  await bob.destroy()
 })
 
-test('multiple rpcs', async t => {
+test('hyperswarm - multiple rpcs', async t => {
   const testnet = await createTestnet(3, t.teardown)
 
   t.plan(6)
@@ -135,11 +123,11 @@ test('multiple rpcs', async t => {
   await alice.listen()
 
   aliceFoo.on('handshake', handshake =>
-    t.is(handshake, 'foo-handshake:for:' + alice.id)
+    t.is(handshake, 'foo-handshake:for:' + b4a.toString(alice.keyPair.publicKey, 'hex'))
   )
 
   aliceBar.on('handshake', handshake =>
-    t.is(handshake, 'bar-handshake:for:' + alice.id)
+    t.is(handshake, 'bar-handshake:for:' + b4a.toString(alice.keyPair.publicKey, 'hex'))
   )
 
   aliceFoo.once('echo', req => t.is(req, 'foo'))


### PR DESCRIPTION
this is a backward compatible change, but will make Slashtag.connect() redundant and should be deprecated

waiting on atomic test all the way in Bitkit